### PR TITLE
feat: add donation eligibility and history tracking

### DIFF
--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -40,7 +40,7 @@
 @SET __MVNW_ARG0_NAME__=
 @SET MVNW_USERNAME=
 @SET MVNW_PASSWORD=
-@IF NOT "%__MVNW_CMD__%"=="" (%__MVNW_CMD__% %*)
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
 @echo Cannot start maven from wrapper >&2 && exit /b 1
 @GOTO :EOF
 : end batch / begin powershell #>

--- a/project-feats.md
+++ b/project-feats.md
@@ -1,0 +1,101 @@
+# 🩸 Blood Donor Finder - Project Features
+
+**Blood Donor Finder** is a production-ready RESTful backend API that connects blood donors with recipients in emergencies. Every feature listed here is fully implemented and backed by working code.
+
+---
+
+## ✅ Implemented Features
+
+### 1. 🔐 User Management & Role-Based Access
+- **Registration**: Donors and receivers can register with name, email, phone, blood group, and geo-location via `POST /api/user/register`.
+- **Profile Update**: Users can update their availability, location, blood group, and last donation date via `POST /api/user/update`.
+- **Role System**: Three distinct roles — `ADMIN`, `DONOR`, `RECEIVER` — are enforced at the data layer.
+
+---
+
+### 2. 📍 Proximity-Based Donor Discovery
+- **Geo-Location Search**: Finds nearby donors using latitude & longitude coordinates.
+- **Haversine Formula**: Calculates real earth-surface distances between the requester and each donor to ensure accuracy.
+- **Blood Group Filtering**: Only donors with a matching blood group are fetched from the database.
+- **Radius-Based Results**: Defaults to a 10 km radius if not specified by the caller.
+- **Endpoint**: `GET /api/search/notify-near-by-donors`
+
+---
+
+### 3. 🩺 Donation Eligibility & History Tracking *(new)*
+- **120-Day Eligibility Rule**: Automatically skips donors who donated within the last **120 days** during every search — enforcing safe donation intervals without any manual check.
+- **Smart Search Integration**: Eligibility filtering runs inside `DonorSearchServiceImpl` before distance calculation, keeping ineligible donors completely out of results.
+- **Record Donation**: Logs a completed donation (donor, optional recipient, optional blood request, notes) and instantly updates the donor's `lastDonationDate`.
+- **Donation History**: Retrieves a donor's full donation log, sorted from most recent to oldest.
+- **Endpoints**:
+  - `POST /api/donations/record`
+  - `GET  /api/donations/history/{donorId}`
+  - `GET  /api/donations/eligible/{donorId}`
+
+---
+
+### 4. 📧 Email Notification Pipeline
+- **Automated Email Alerts**: Matched donors automatically receive a rich HTML email containing the requester's location, phone, and hospital name.
+- **Email Validation**: Only donors with valid email addresses are notified — invalid addresses are logged and skipped.
+- **Spring Mail Integration**: Backed by `spring-boot-starter-mail` for reliable SMTP delivery.
+- **Endpoint**: `POST /api/mail/send`
+
+---
+
+### 5. ⚡ Asynchronous Notification via Apache Kafka
+- **Event-Driven Architecture**: After finding eligible donors, `DonorListPublisher` serialises them into a Kafka message and publishes to a dedicated topic.
+- **Decoupled Consumer**: `DonorListConsumer` listens on the topic and dispatches notifications in a separate thread pool (`ExecutorService` with 10 threads), keeping the search API fast and non-blocking.
+- **Rich Message Headers**: Each Kafka message carries `X-Notification-ID`, `X-Emergency-Level`, `X-Blood-Group`, and `X-Donor-Count` headers for traceability.
+- **Acknowledgment Support**: The consumer uses manual acknowledgment for reliable message processing.
+
+---
+
+### 6. 🔍 Elasticsearch-Powered User Search
+- **Index & Store**: User profiles are indexed into Elasticsearch via `POST /es/users/save`.
+- **Blood Group Search**: Query donors by blood group at high speed via `GET /es/users/search_by_bloodgroup`.
+- **Paginated Full-Text Search**: Advanced multi-field search with pagination support via `POST /es/users/search-user`.
+- **Dedicated Document Model**: `UserSearchDocument` is a separate Elasticsearch document (decoupled from the JPA `User` entity).
+
+---
+
+### 7. 🩸 Blood Request Management
+- **Create Request**: Receivers submit a blood request with needed blood group, location, quantity, and an optional message via `POST /api/blood-request/create`.
+- **Request Tracking**: Each request is timestamped and stored with a `PENDING` status by default.
+- **Linked to Users**: Every request is linked to the requester's user record.
+
+---
+
+## 🛠️ Technology Stack
+
+| Layer | Technology | Purpose |
+| :--- | :--- | :--- |
+| **Backend** | Spring Boot 3.4.4 | Core application framework |
+| **Database** | PostgreSQL 15 | Persistent relational data storage |
+| **Messaging** | Apache Kafka (Confluent 7.5) | Async, event-driven notification pipeline |
+| **Search Engine** | Elasticsearch 8.11 | High-speed donor indexing and search |
+| **ORM** | Spring Data JPA | Simplified database access layer |
+| **Email** | Spring Boot Mail (SMTP) | HTML email delivery to donors |
+| **API Docs** | SpringDoc OpenAPI 2.5 | Auto-generated Swagger UI |
+| **Containerization** | Docker & Docker Compose | One-command infra setup |
+| **Build Tool** | Maven Wrapper | Reproducible builds without a local Maven install |
+| **Utilities** | Lombok, Jackson | Boilerplate reduction and JSON serialization |
+
+---
+
+## 📑 API Reference
+
+| Method | Endpoint | Description |
+| :--- | :--- | :--- |
+| `POST` | `/api/user/register` | Register a new user |
+| `POST` | `/api/user/update` | Update user profile |
+| `POST` | `/api/blood-request/create` | Create a blood request |
+| `GET` | `/api/search/notify-near-by-donors` | Find & notify nearby eligible donors |
+| `POST` | `/api/donations/record` | Record a completed donation |
+| `GET` | `/api/donations/history/{donorId}` | Get a donor's full donation history |
+| `GET` | `/api/donations/eligible/{donorId}` | Check if a donor is eligible to donate |
+| `POST` | `/api/mail/send` | Send a notification email manually |
+| `POST` | `/es/users/save` | Index a user into Elasticsearch |
+| `GET` | `/es/users/search_by_bloodgroup` | Search donors by blood group (ES) |
+| `POST` | `/es/users/search-user` | Paginated full-text search (ES) |
+
+> 🔗 Full interactive docs: **http://localhost:8080/swagger-ui/index.html**

--- a/src/main/java/com/bd/blooddonerfinder/controller/DonationHistoryController.java
+++ b/src/main/java/com/bd/blooddonerfinder/controller/DonationHistoryController.java
@@ -1,0 +1,47 @@
+package com.bd.blooddonerfinder.controller;
+
+import com.bd.blooddonerfinder.model.DonationHistory;
+import com.bd.blooddonerfinder.model.User;
+import com.bd.blooddonerfinder.repository.UserRepository;
+import com.bd.blooddonerfinder.service.DonationHistoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/donations")
+@RequiredArgsConstructor
+public class DonationHistoryController {
+
+    private final DonationHistoryService donationHistoryService;
+    private final UserRepository userRepository;
+
+    @PostMapping("/record")
+    public ResponseEntity<DonationHistory> recordDonation(@RequestBody Map<String, Object> body) {
+        Long donorId = Long.valueOf(body.get("donorId").toString());
+        Long recipientId = body.get("recipientId") != null ? Long.valueOf(body.get("recipientId").toString()) : null;
+        Long requestId  = body.get("requestId")  != null ? Long.valueOf(body.get("requestId").toString())  : null;
+        String notes = body.get("notes") != null ? body.get("notes").toString() : null;
+        return ResponseEntity.ok(donationHistoryService.recordDonation(donorId, recipientId, requestId, notes));
+    }
+
+    @GetMapping("/history/{donorId}")
+    public ResponseEntity<List<DonationHistory>> getDonorHistory(@PathVariable Long donorId) {
+        return ResponseEntity.ok(donationHistoryService.getDonorHistory(donorId));
+    }
+
+    @GetMapping("/eligible/{donorId}")
+    public ResponseEntity<Map<String, Object>> checkEligibility(@PathVariable Long donorId) {
+        User donor = userRepository.findById(donorId)
+                .orElseThrow(() -> new RuntimeException("Donor not found with id: " + donorId));
+        boolean eligible = donationHistoryService.isEligibleToDonate(donor);
+        return ResponseEntity.ok(Map.of(
+                "donorId", donorId,
+                "eligible", eligible,
+                "lastDonationDate", donor.getLastDonationDate() != null ? donor.getLastDonationDate().toString() : "Never donated"
+        ));
+    }
+}

--- a/src/main/java/com/bd/blooddonerfinder/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/bd/blooddonerfinder/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.bd.blooddonerfinder.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/bd/blooddonerfinder/model/DonationHistory.java
+++ b/src/main/java/com/bd/blooddonerfinder/model/DonationHistory.java
@@ -1,32 +1,37 @@
 package com.bd.blooddonerfinder.model;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.*;
 import lombok.Data;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Data
+@Table(name = "donation_history")
 public class DonationHistory {
+
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "donor_id", nullable = false)
+    @JsonIgnoreProperties({"geoLocation", "createdAt", "updatedAt", "hibernateLazyInitializer"})
     private User donor;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recipient_id")
+    @JsonIgnoreProperties({"geoLocation", "createdAt", "updatedAt", "hibernateLazyInitializer"})
     private User recipient;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "request_id")
+    @JsonIgnoreProperties({"geoLocation", "hibernateLazyInitializer"})
     private BloodRequest request;
 
     private LocalDateTime donationDate;
     private String notes;
-
     private Boolean verified;
 
 }

--- a/src/main/java/com/bd/blooddonerfinder/repository/DonationHistoryRepository.java
+++ b/src/main/java/com/bd/blooddonerfinder/repository/DonationHistoryRepository.java
@@ -1,0 +1,13 @@
+package com.bd.blooddonerfinder.repository;
+
+import com.bd.blooddonerfinder.model.DonationHistory;
+import com.bd.blooddonerfinder.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface DonationHistoryRepository extends JpaRepository<DonationHistory, Long> {
+    List<DonationHistory> findByDonorOrderByDonationDateDesc(User donor);
+}

--- a/src/main/java/com/bd/blooddonerfinder/service/DonationHistoryService.java
+++ b/src/main/java/com/bd/blooddonerfinder/service/DonationHistoryService.java
@@ -1,0 +1,11 @@
+package com.bd.blooddonerfinder.service;
+
+import com.bd.blooddonerfinder.model.DonationHistory;
+import com.bd.blooddonerfinder.model.User;
+import java.util.List;
+
+public interface DonationHistoryService {
+    DonationHistory recordDonation(Long donorId, Long recipientId, Long requestId, String notes);
+    List<DonationHistory> getDonorHistory(Long donorId);
+    boolean isEligibleToDonate(User donor);
+}

--- a/src/main/java/com/bd/blooddonerfinder/service/DonationHistoryServiceImpl.java
+++ b/src/main/java/com/bd/blooddonerfinder/service/DonationHistoryServiceImpl.java
@@ -1,0 +1,75 @@
+package com.bd.blooddonerfinder.service;
+
+import com.bd.blooddonerfinder.exception.ResourceNotFoundException;
+import com.bd.blooddonerfinder.model.BloodRequest;
+import com.bd.blooddonerfinder.model.DonationHistory;
+import com.bd.blooddonerfinder.model.User;
+import com.bd.blooddonerfinder.repository.BloodRequestRepository;
+import com.bd.blooddonerfinder.repository.DonationHistoryRepository;
+import com.bd.blooddonerfinder.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DonationHistoryServiceImpl implements DonationHistoryService {
+
+    private final DonationHistoryRepository donationHistoryRepository;
+    private final UserRepository userRepository;
+    private final BloodRequestRepository bloodRequestRepository;
+
+    private static final int ELIGIBILITY_DAYS = 120; // 4 months
+
+    @Override
+    @Transactional
+    public DonationHistory recordDonation(Long donorId, Long recipientId, Long requestId, String notes) {
+        User donor = userRepository.findById(donorId)
+                .orElseThrow(() -> new ResourceNotFoundException("Donor not found"));
+        
+        User recipient = null;
+        if (recipientId != null) {
+            recipient = userRepository.findById(recipientId).orElse(null);
+        }
+
+        BloodRequest request = null;
+        if (requestId != null) {
+            request = bloodRequestRepository.findById(requestId).orElse(null);
+        }
+
+        DonationHistory history = new DonationHistory();
+        history.setDonor(donor);
+        history.setRecipient(recipient);
+        history.setRequest(request);
+        history.setDonationDate(LocalDateTime.now());
+        history.setNotes(notes);
+        history.setVerified(true);
+
+        // Update donor's last donation date
+        donor.setLastDonationDate(LocalDate.now());
+        userRepository.save(donor);
+
+        return donationHistoryRepository.save(history);
+    }
+
+    @Override
+    public List<DonationHistory> getDonorHistory(Long donorId) {
+        User donor = userRepository.findById(donorId)
+                .orElseThrow(() -> new ResourceNotFoundException("Donor not found"));
+        return donationHistoryRepository.findByDonorOrderByDonationDateDesc(donor);
+    }
+
+    @Override
+    public boolean isEligibleToDonate(User donor) {
+        if (donor.getLastDonationDate() == null) {
+            return true;
+        }
+        long daysSinceLastDonation = ChronoUnit.DAYS.between(donor.getLastDonationDate(), LocalDate.now());
+        return daysSinceLastDonation >= ELIGIBILITY_DAYS;
+    }
+}

--- a/src/main/java/com/bd/blooddonerfinder/service/DonorSearchServiceImpl.java
+++ b/src/main/java/com/bd/blooddonerfinder/service/DonorSearchServiceImpl.java
@@ -16,10 +16,11 @@ import java.util.List;
 @Slf4j
 public class DonorSearchServiceImpl implements DonorSearchService{
     private final UserRepository userRepository;
+    private final DonationHistoryService donationHistoryService;
 
-    public DonorSearchServiceImpl(UserRepository userRepository) {
+    public DonorSearchServiceImpl(UserRepository userRepository, DonationHistoryService donationHistoryService) {
         this.userRepository = userRepository;
-
+        this.donationHistoryService = donationHistoryService;
     }
 
     @Override
@@ -27,6 +28,13 @@ public class DonorSearchServiceImpl implements DonorSearchService{
         List<User> allDonors = userRepository.findNearByRoleAndBloodGroup(Role.DONOR, searchRequest.getBloodGroup());
         List<User> nearByDonors = new ArrayList<>();
         for(User user : allDonors){
+            // Check eligibility first
+            if (!donationHistoryService.isEligibleToDonate(user)) {
+                log.debug("Donor {} is not eligible to donate yet (last donation: {})", 
+                        user.getEmail(), user.getLastDonationDate());
+                continue;
+            }
+
             GeoLocation geoLocation = user.getGeoLocation();
             if (geoLocation == null || geoLocation.getLatitude() == null || geoLocation.getLongitude() == null){
                 continue;


### PR DESCRIPTION
- Add DonationHistory entity with proper JPA mappings and @JsonIgnoreProperties to prevent circular serialization
- Add DonationHistoryRepository with query to fetch history sorted by date
- Add DonationHistoryService interface and DonationHistoryServiceImpl with 120-day eligibility rule
- Integrate eligibility check into DonorSearchServiceImpl to automatically filter ineligible donors
- Add DonationHistoryController with record, history, and eligibility check endpoints
- Add ResourceNotFoundException for consistent error handling
- Update project-feats.md with all verified implemented features and full API reference table